### PR TITLE
Improvement - Updating props update existing chart instead of creating new one.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import Chartkick from "chartkick"
 let chartId = 1
 
 class ChartComponent extends React.Component {
-  newChartType(props) {
+  getChartDataAndOptions(props) {
     const data = props.data
     const options = {}
     for (const prop in props) {
@@ -12,17 +12,29 @@ class ChartComponent extends React.Component {
         options[prop] = props[prop]
       }
     }
+    return {data, options}
+  }
+
+  createChart(props) {
+    const {data, options} = this.getChartDataAndOptions(props)
     if (this.element) {
-      new props.chartType(this.element, data, options)
+      this.chart = new props.chartType(this.element, data, options)
+    }
+  }
+
+  updateChart(props) {
+    const {data, options} = this.getChartDataAndOptions(props)
+    if (this.element) {
+      this.chart.updateData(data, options)
     }
   }
 
   componentDidMount() {
-    this.newChartType(this.props)
+    this.createChart(this.props)
   }
 
   componentDidUpdate() {
-    this.newChartType(this.props)
+    this.updateChart(this.props)
   }
 
   render() {


### PR DESCRIPTION
Hi!
First, thanks for the great lib! I've searched thorough a lot of react wrappers for some chart libs, and this one suits the best for me :)

I've spotted probably (I'm never sure ;p) unwanted behavior. When the props are updated component is creating new chartkick chart and don't destroy previous one. It can lead to great memory leak when for instance we're updating chart data in some interval.

So I've created this little pr to update existing chart instead of creating new one. It's working for the case I'm using it for. 

I've tried to follow existing coding style. Although I'll be happy to make some changes if you want :)

Cheers