### PR TITLE
Create forward ref to make Chartkick API accessible

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -50,8 +50,8 @@ class ChartComponent extends React.Component {
 }
 
 const createComponent = (chartType) => {
-  const ChartkickComponent = (props) => {
-    return React.createElement(ChartComponent, Object.assign({}, props, {chartType: chartType}))
+  const ChartkickComponent = ({innerRef, ...props}) => {
+    return React.createElement(ChartComponent, Object.assign({}, props, {chartType: chartType, ref: innerRef}))
   }
   ChartkickComponent.displayName = chartType.name
   return ChartkickComponent

--- a/src/index.js
+++ b/src/index.js
@@ -50,9 +50,11 @@ class ChartComponent extends React.Component {
 }
 
 const createComponent = (chartType) => {
-  return (props) => {
+  const ChartkickComponent = (props) => {
     return React.createElement(ChartComponent, Object.assign({}, props, {chartType: chartType}))
   }
+  ChartkickComponent.displayName = chartType.name
+  return ChartkickComponent
 }
 
 export const LineChart = createComponent(Chartkick.LineChart)


### PR DESCRIPTION
This PR does 2 things:

- Creates a forward ref to make Chartkick API accessible outside the component. This is important for updating data easily from a parent component.
- Adds a `displayName` that is set dynamically based on the chart type. This makes debugging in React DevTools easier because instead of showing up as `<Unknown>` the component will show up as `<LineChart>` or whatever the chart type is.