### PR TITLE
Updated Charts to work in IE

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "rollup-plugin-uglify": "^6.0.2"
   },
   "dependencies": {
-    "chartkick": "^3.1.0"
+    "chartkick": "^3.1.0",
+    "lodash.assign": "^4.2.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import React from "react"
 import Chartkick from "chartkick"
+import Assign from 'lodash.assign'
 
 let chartId = 1
 
@@ -51,7 +52,7 @@ class ChartComponent extends React.Component {
 
 const createComponent = (chartType) => {
   const ChartkickComponent = ({innerRef, ...props}) => {
-    return React.createElement(ChartComponent, Object.assign({}, props, {chartType: chartType, ref: innerRef}))
+    return React.createElement(ChartComponent, Assign({}, props, {chartType: chartType, ref: innerRef}))
   }
   ChartkickComponent.displayName = chartType.name
   return ChartkickComponent


### PR DESCRIPTION
Object.assign is unavailable in IE, replaced with Lodash.assign