### PR TITLE
Fixed unmount destroy chart

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,12 @@ class ChartComponent extends React.Component {
     this.newChartType(this.props)
   }
 
+  componentWillUnmount() {
+    if (this.chart) {
+      this.chart.destroy()
+    }
+  }
+
   render() {
     const props = this.props
     const style = {


### PR DESCRIPTION
Currenty, `componentWillUnmount` is not calling `chart.destroy()` , which leads to a chart component with a `refresh` option will continuously fetch chart data in background after the chart component is unmounted. This pull request fixes that.