### PR TITLE
Fixed No data in React.StrictMode

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,6 +32,7 @@ class ChartComponent extends React.Component {
   componentWillUnmount() {
     if (this.chart) {
       this.chart.destroy()
+      this.chart = undefined
     }
   }
 


### PR DESCRIPTION
`<React.StrictMode />` mount and unmount Component twice in development mode.

This would cause `this.chart.updateData` to be called on a destroyed chart, cause `No data` to be shown.